### PR TITLE
Validate deployments reference contract types

### DIFF
--- a/ethpm/package.py
+++ b/ethpm/package.py
@@ -1,14 +1,16 @@
 from ethpm.exceptions import ValidationError
 
 from ethpm.utils.package_validation import (
-    load_and_validate_package,
-    validate_package_exists
+    load_package_data,
+    validate_package_against_schema,
+    validate_package_exists,
+    validate_package_deployments,
 )
 from ethpm.utils.contract import (
+    generate_contract_factory_kwargs,
     validate_contract_name,
     validate_minimal_contract_data_present,
-    generate_contract_factory_kwargs,
-    validate_w3_instance
+    validate_w3_instance,
 )
 
 
@@ -25,8 +27,11 @@ class Package(object):
         self.package_id = package_id
 
         validate_package_exists(package_id)
-        valid_package_data = load_and_validate_package(package_id)
-        self.package_data = valid_package_data
+        package_data = load_package_data(package_id)
+        validate_package_against_schema(package_data)
+        validate_package_deployments(package_data)
+
+        self.package_data = package_data
 
     def set_default_w3(self, w3):
         """

--- a/ethpm/utils/package_validation.py
+++ b/ethpm/utils/package_validation.py
@@ -1,18 +1,23 @@
 import json
 import os
 
-from ethpm import ASSETS_DIR
-from ethpm.exceptions import ValidationError
-
 from jsonschema import (
     validate,
     ValidationError as jsonValidationError
 )
 
+from ethpm import ASSETS_DIR
+
+from ethpm.exceptions import ValidationError
+
+
 RELEASE_LOCKFILE_SCHEMA_PATH = os.path.join(ASSETS_DIR, 'release-lockfile.schema.v1.json')
 
 
-def _load_package_data(package_id):
+def load_package_data(package_id):
+    """
+    Load package json located in ASSETS_DIR.
+    """
     with open(os.path.join(ASSETS_DIR, package_id)) as package:
         return json.load(package)
 
@@ -22,20 +27,42 @@ def _load_schema_data():
         return json.load(schema)
 
 
-def load_and_validate_package(package_id):
+def validate_package_against_schema(package_data):
     """
     Load and validate package json against schema
     located at RELEASE_LOCKFILE_SCHEMA_PATH.
     """
     schema_data = _load_schema_data()
-    package_data = _load_package_data(package_id)
     try:
         validate(package_data, schema_data)
     except jsonValidationError:
         raise ValidationError(
-            "Package:{0} invalid for schema:{1}".format(package_id, RELEASE_LOCKFILE_SCHEMA_PATH)
+            "Package:{0} invalid for schema:{1}".format(package_data, RELEASE_LOCKFILE_SCHEMA_PATH)
         )
-    return package_data
+
+
+def validate_package_deployments(package_data):
+    """
+    Validate that a package's deployments contracts reference existing contract_types.
+    """
+    if set(("contract_types", "deployments")).issubset(package_data):
+        all_contract_types = list(package_data["contract_types"].keys())
+
+        deployments = [
+            deployment
+            for uri, deployment
+            in package_data["deployments"].items()
+        ]
+        deployment_names = [
+            name
+            for name, value
+            in deployments[0].items()
+        ]
+
+        if not deployment_names <= all_contract_types:
+            raise ValidationError(
+                "Deployments:{0} do not reference existing contract types.".format(deployment_names)
+            )
 
 
 def validate_package_exists(package_id):

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts= -v --showlocals --durations 10
+addopts= -v --showlocals
 python_paths= .
 
 [pytest-watch]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,64 @@
+import copy
+import json
+import pytest
+
+
+LOCKFILE = {
+  "lockfile_version": "1",
+  "version": "1.0.0",
+  "package_name": "safe-math-lib",
+  "contract_types": {
+    "SafeMathLib": {
+      "bytecode": "0x606060405234610000575b60a9806100176000396000f36504062dabbdf050606060405260e060020a6000350463a293d1e88114602e578063e6cb901314604c575b6000565b603a600435602435606a565b60408051918252519081900360200190f35b603a6004356024356088565b60408051918252519081900360200190f35b6000828211602a57508082036081566081565b6000565b5b92915050565b6000828284011115602a57508181016081566081565b6000565b5b9291505056",
+      "runtime_bytecode": "0x6504062dabbdf050606060405260e060020a6000350463a293d1e88114602e578063e6cb901314604c575b6000565b603a600435602435606a565b60408051918252519081900360200190f35b603a6004356024356088565b60408051918252519081900360200190f35b6000828211602a57508082036081566081565b6000565b5b92915050565b6000828284011115602a57508181016081566081565b6000565b5b9291505056",
+      "compiler": {
+        "type": "solc",
+        "version": "0.4.6+commit.2dabbdf0.Darwin.appleclang",
+        "settings": {
+            "optimize": True
+        }
+      }
+    }
+  },
+  "deployments": {
+    "blockchain://41941023680923e0fe4d74a34bdac8141f2540e3ae90623718e47d66d1ca4a2d/block/1e96de11320c83cca02e8b9caf3e489497e8e432befe5379f2f08599f8aecede": {
+      "SafeMathLib": {
+        "contract_type": "SafeMathLib",
+        "address": "0x8d2c532d7d211816a2807a411f947b211569b68c",
+        "transaction": "0xaceef751507a79c2dee6aa0e9d8f759aa24aab081f6dcf6835d792770541cb2b",
+        "block": "0x420cb2b2bd634ef42f9082e1ee87a8d4aeeaf506ea5cdeddaa8ff7cbf911810c"
+      }
+    }
+  }
+}
+
+@pytest.fixture
+def lockfile_with_matching_deployments(tmpdir):
+    f = tmpdir.join("lockfile.json")
+    f.write(json.dumps(LOCKFILE))
+    return str(f)
+
+
+@pytest.fixture
+def lockfile_with_no_deployments(tmpdir):
+    lockfile = copy.deepcopy(LOCKFILE)
+    lockfile.pop("deployments")
+    f = tmpdir.join("lockfile.json")
+    f.write(json.dumps(lockfile))
+    return str(f)
+
+
+@pytest.fixture
+def lockfile_with_conflicting_deployments(tmpdir):
+    lockfile = copy.deepcopy(LOCKFILE)
+    lockfile["deployments"]["blockchain://41941023680923e0fe4d74a34bdac8141f2540e3ae90623718e47d66d1ca4a2d/block/1e96de11320c83cca02e8b9caf3e489497e8e432befe5379f2f08599f8aecede"] = {
+      "WrongNameLib": {
+        "contract_type": "SafeMathLib",
+        "address": "0x8d2c532d7d211816a2807a411f947b211569b68c",
+        "transaction": "0xaceef751507a79c2dee6aa0e9d8f759aa24aab081f6dcf6835d792770541cb2b",
+        "block": "0x420cb2b2bd634ef42f9082e1ee87a8d4aeeaf506ea5cdeddaa8ff7cbf911810c"
+      }
+    }
+    f = tmpdir.join("lockfile.json")
+    f.write(json.dumps(lockfile))
+    return str(f)

--- a/tests/ethpm/test_package.py
+++ b/tests/ethpm/test_package.py
@@ -1,10 +1,16 @@
 import pytest
 
-from web3 import Web3
 from eth_tester import EthereumTester
+
+from web3 import Web3
+
+from web3.providers.eth_tester import (
+    EthereumTesterProvider,
+)
+
 from ethpm.package import Package
+
 from ethpm.exceptions import ValidationError
-from web3.providers.eth_tester import EthereumTesterProvider
 
 
 def test_ethpm_exists():


### PR DESCRIPTION
### What was wrong?
No validation that all deployments reference existing contract types in a package.

@pipermerriam - I can't quite remember for what kind of lockfiles are in scope for this pr. But this validation is currently built for packages with deployments with a single uri.

I also split up the load & validation logic into separate functions when you init a Package.

### How was it fixed?
Wrote the validation.

#### Cute Animal Picture

![giphy 38](https://user-images.githubusercontent.com/9753150/33530002-274d940e-d836-11e7-9e32-4a6fb8c7bf24.gif)
